### PR TITLE
feat: Support cloning multiple Git repositories with cloud passports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ There are two ways to specify clusters:
     ```shell
    docker run -e ENV_INSTANCES_REPO=https://github.com/ormig/cloud-passport-samples.git -i --rm -p 8080:8080 ghcr.io/netcracker/qubership-colly:latest
     ```
-    The application will clone the repository `https://github.com/ormig/cloud-passport-samples.git` and read all cloud passports for each cluster. If authentication is required to clone a repository, you can specify it in URL:
+   multiple repositories can be specified using comma-separated values. For example:
+    ```shell
+   docker run -e ENV_INSTANCES_REPO=https://github.com/repo1.git,https://github.com/repo2.git -i --rm -p 8080:8080 ghcr.io/netcracker/qubership-colly:latest
+    ```
+   The application will clone the repository `https://github.com/ormig/cloud-passport-samples.git` and read all cloud passports for each cluster. If authentication is required to clone a repository, you can specify it in URL:
     ```shell
       docker run -e ENV_INSTANCES_REPO=https://myusername:mypassword@github.com/ormig/cloud-passport-samples.git -i --rm -p 8080:8080 ghcr.io/netcracker/qubership-colly:latest
     ```

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ kubeconfigs.path=/kubeconfigs
 %test.kubeconfigs.path=./src/test/resources/kubeconfigs
 %dev.kubeconfigs.path=./src/test/resources/kubeconfigs
 
-%dev.env.instances.repo=https://github.com/ormig/cloud-passport-samples.git
+%dev.env.instances.repo=https://github.com/ormig/cloud-passport-samples.git,https://github.com/ormig/cloud-passport-samples.git
 %test.env.instances.repo=42;
 
 cloud.passport.folder=./git-repo


### PR DESCRIPTION
### Description

This pull request introduces the ability to clone multiple Git repositories in a single operation. It addresses and resolves functionality requested in issue #47.

### Changes Made

- Added support for handling multiple repository URLs during cloning.

