### PR TITLE
fix: append deployment version only if unique and non-empty, update test cases for multiple namespaces

### DIFF
--- a/src/main/java/org/qubership/colly/ClusterResourcesLoader.java
+++ b/src/main/java/org/qubership/colly/ClusterResourcesLoader.java
@@ -163,7 +163,11 @@ public class ClusterResourcesLoader {
                     Log.info("Setting clean installation date for environment " + environment.getName() + " to " + configMapCreationTime);
                     environment.setCleanInstallationDate(configMapCreationTime);
                 }
-                deploymentVersions.append(versionsConfigMap.getData().get(versionsConfigMapDataFieldName)).append("\n");
+
+                String deploymentVersionForNamespace = versionsConfigMap.getData().get(versionsConfigMapDataFieldName);
+                if (deploymentVersionForNamespace != null && !deploymentVersionForNamespace.trim().isEmpty() && !deploymentVersions.toString().contains(deploymentVersionForNamespace)) {
+                    deploymentVersions.append(deploymentVersionForNamespace).append("\n");
+                }
                 Log.info("Namespace " + namespace.getName() + " is loaded successfully. Deployment versions are: " + deploymentVersions);
             }
             environment.setMonitoringData(monitoringService.loadMonitoringData(monitoringUri, environment.getNamespaces().stream().map(Namespace::getName).toList()));

--- a/src/test/java/org/qubership/colly/ClusterResourcesLoaderTest.java
+++ b/src/test/java/org/qubership/colly/ClusterResourcesLoaderTest.java
@@ -216,8 +216,9 @@ class ClusterResourcesLoaderTest {
         CloudPassport cloudPassport = new CloudPassport(CLUSTER_NAME, "42", "https://api.example.com",
                 Set.of(new CloudPassportEnvironment("env-3-namespaces", "some env for tests",
                         List.of(new CloudPassportNamespace(NAMESPACE_NAME),
-                                new CloudPassportNamespace(NAMESPACE_NAME_2)))), null);
-        mockNamespaceLoading(CLUSTER_NAME, List.of(NAMESPACE_NAME, NAMESPACE_NAME_2));
+                                new CloudPassportNamespace(NAMESPACE_NAME_2),
+                                new CloudPassportNamespace(NAMESPACE_NAME_3)))), null);
+        mockNamespaceLoading(CLUSTER_NAME, List.of(NAMESPACE_NAME, NAMESPACE_NAME_2, NAMESPACE_NAME_3));
 
         V1ConfigMap configMap1 = new V1ConfigMap()
                 .metadata(new V1ObjectMeta().name("sd-versions").uid("configmap-uid").creationTimestamp(DATE_2025))
@@ -230,6 +231,14 @@ class ClusterResourcesLoaderTest {
                 .data(Map.of("solution-descriptors-summary", "MyVersion 2.0.0"));
 
         mockConfigMaps(List.of(configMap2), NAMESPACE_NAME_2);
+
+         V1ConfigMap configMap3 = new V1ConfigMap()
+                .metadata(new V1ObjectMeta().name("sd-versions").uid("configmap-uid").creationTimestamp(DATE_2025))
+                .data(Map.of("solution-descriptors-summary", "MyVersion 2.0.0"));
+
+        mockConfigMaps(List.of(configMap3), NAMESPACE_NAME_3);
+
+
 
         clusterResourcesLoader.loadClusterResources(coreV1Api, cloudPassport);
         Environment testEnv = environmentRepository.findByNameAndCluster("env-3-namespaces", CLUSTER_NAME);


### PR DESCRIPTION
There is a problem with deployment version duplication in case when several namespaces has the same version. So PR should fix the problem.